### PR TITLE
商品編集ページの実装

### DIFF
--- a/app/controllers/sells_controller.rb
+++ b/app/controllers/sells_controller.rb
@@ -1,5 +1,6 @@
 class SellsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
+  before_action :move_to_index, only: :edit
   def index
     @sells = Sell.order('created_at DESC')
   end
@@ -40,5 +41,12 @@ class SellsController < ApplicationController
   def sell_params
     params.require(:sell).permit(:product_name, :product_description, :category_id, :product_condition_id, :delivery_fee_id,
                                  :shipping_area_id, :day_id, :image, :price).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @sell = Sell.find(params[:id])
+      unless @sell.user_id == current_user.id
+        redirect_to root_path
+      end
   end
 end

--- a/app/controllers/sells_controller.rb
+++ b/app/controllers/sells_controller.rb
@@ -1,5 +1,5 @@
 class SellsController < ApplicationController
-  before_action :authenticate_user!, only: :new
+  before_action :authenticate_user!, only: [:new, :edit]
   def index
     @sells = Sell.order('created_at DESC')
   end
@@ -20,6 +20,19 @@ class SellsController < ApplicationController
 
   def show
     @sell = Sell.find(params[:id])
+  end
+
+  def edit
+    @sell = Sell.find(params[:id])
+  end
+
+  def update
+    @sell = Sell.find(params[:id])
+    if @sell.update(sell_params) # updateメソッドの引数tweet_paramsでは、どの情報を更新するかを指定
+      redirect_to sell_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/sells_controller.rb
+++ b/app/controllers/sells_controller.rb
@@ -1,6 +1,7 @@
 class SellsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :move_to_index, only: :edit
+  before_action :set_sell, except: [:index, :new]
   def index
     @sells = Sell.order('created_at DESC')
   end
@@ -10,7 +11,6 @@ class SellsController < ApplicationController
   end
 
   def create
-    @sell = Sell.new(sell_params)
     if @sell.valid?
       @sell.save
       redirect_to root_path
@@ -20,15 +20,13 @@ class SellsController < ApplicationController
   end
 
   def show
-    @sell = Sell.find(params[:id])
   end
 
   def edit
-    @sell = Sell.find(params[:id])
+
   end
 
   def update
-    @sell = Sell.find(params[:id])
     if @sell.update(sell_params) # updateメソッドの引数tweet_paramsでは、どの情報を更新するかを指定
       redirect_to sell_path
     else
@@ -48,5 +46,9 @@ class SellsController < ApplicationController
       unless @sell.user_id == current_user.id
         redirect_to root_path
       end
+  end
+
+  def set_sell
+    @sell = Sell.find(params[:id])
   end
 end

--- a/app/views/sells/edit.html.erb
+++ b/app/views/sells/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @sell, local: true) do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id: @sell.image %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :product_description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:product_condition_id, ProductCondition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area_id, ShippingArea.all, :id, :name,  {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/sells/show.html.erb
+++ b/app/views/sells/show.html.erb
@@ -26,7 +26,7 @@
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %>
       <% if current_user.id == @sell.user_id %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_sell_path, method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'sells#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :sells, only: [:index, :new, :create, :show]
+  resources :sells, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# WHAT
商品の編集ページ画面の編集、更新できた時できなかった時の編集
# WHY
商品編集ページの実装するため
[商品編集に成功]
(url)https://gyazo.com/683a9fbdcad03fb4a0165f0327e1d533
[商品編集に失敗し、エラーが表示]
(url)https://gyazo.com/bfcc037fa346bfcd0963a1ceadf44da9
[何も編集せずに更新をしても画像無しの商品にならない]
(url)https://gyazo.com/d051745250ac84703899fe234d644e28
[ログイン状態の出品者だけが商品情報編集ページに遷移]
(url)https://gyazo.com/208192f61879882c81508ecef4a0ef82
[ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移]
(url)https://gyazo.com/e1837b9ef26c65e38a937effc2f60965
[ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移]
(url)https://gyazo.com/e161f1fdfd68983648e15ce177d648a7
[商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示]
(url)https://gyazo.com/c71218922fbcd1bf5f983dfba96bb48b